### PR TITLE
Update nft-lend-borrow.ts

### DIFF
--- a/tests/nft-lend-borrow.ts
+++ b/tests/nft-lend-borrow.ts
@@ -735,7 +735,7 @@ describe("nft-lend-borrow", () => {
         await program.methods
             .withdrawOffer(
                 new anchor.BN(minimumBalanceForRentExemption),
-                collectionId
+                //collectionId
             )
             .accounts({
                 offerLoan: offerPDA,


### PR DESCRIPTION
Fixes error and successfully runs 9 tests. 
![Screenshot 2023-11-25 at 2 50 39 PM](https://github.com/Calyptus-Learn/Sharky-Fi-clone-using-Escrow/assets/16709708/be1229d4-8504-4ba5-81c5-a7ee5da3d239)
Withdraw_offfer handler supports only one argument.
```
pub fn handler(ctx: Context<WithdrawOffer>, minimum_balance_for_rent_exemption: u64) -> Result<()> {
```
Argument of type '[BN, PublicKey]' is not assignable to parameter of type 'ArgsTuple<[{ name: "minimumBalanceForRentExemption"; type: "u64"; }], DecodedHelper<unknown, EmptyDefined>>'.
  Type '[BN, PublicKey]' is not assignable to type '[BN]'.
    Source has 2 element(s) but target allows only 1.